### PR TITLE
internationalize `main` app with i18n and localize into Japanese

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.python-version
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/README.md
+++ b/README.md
@@ -25,3 +25,56 @@ $ cd project
 $ python manage.py startapp appname
 ```
 
+# how to localize your app(e.g.`main` into Japanese) in your language
+### mark the texts in python files or jinja2 templates which need to be translated
+```
+# in main/views.py
+....
+....
+from kay.i18n import gettext as _ # in views.py
+from kay.i18n import lazy_gettext as _ # in models.py/forms.py
+# you do not have to import any modules in jinja2 template files.
+....
+....
+.... 
+
+# [before marking]
+feed_title = 'Upcoming Event'
+
+# [after marking]
+feed_title = _('Upcoming Event')
+....
+....
+.... 
+```
+
+### at the first time
+```
+$ pwd
+<<your path>>/calendar-app/project
+
+$ python manage.py extract_messages main # Generated `main/i18n/messages.pot`
+$ python manage.py add_translations main -l ja # Generated `main/i18n/ja/LC_MESSAGES/messages.po`
+
+# Open `main/i18n/ja/LC_MESSAGES/messages.po` and translate into the lang
+
+## `main/i18n/ja/LC_MESSAGES/messages.po`
+## ....
+## #: main/views.py:161
+## msgid "Upcoming Event"
+## msgstr "<<Translated strigs>>"
+## ....
+
+$ python manage.py compile_translations main # Generated `main/i18n/ja/LC_MESSAGES/messages.mo`
+```
+### from the second time
+```
+# mark the texts to be tranlated
+$ pwd
+<<your path>>/calendar-app/project
+$ python manage.py extract_messages main
+$ python manage.py update_translations -t main -l ja # diff
+# Edit `main/i18n/ja/LC_MESSAGES/messages.po`
+$ python manage.py compile_translations main
+```
+

--- a/project/kay/i18n/translations.py
+++ b/project/kay/i18n/translations.py
@@ -9,7 +9,10 @@ class KayTranslations(TranslationsBase):
   def __init__(self, fileobj=None, locale=None):
     self.lang = locale
     self._catalog = {}
-    TranslationsBase.__init__(self, fileobj=fileobj)
+    try:
+        TranslationsBase.__init__(self, fileobj=fileobj)
+    except TypeError:
+        TranslationsBase.__init__(self, fp=fileobj)
     if not hasattr(self, "plural"):
       self.plural = lambda n: int(n != 1)
 

--- a/project/kay/management/extract_messages.py
+++ b/project/kay/management/extract_messages.py
@@ -6,7 +6,7 @@ Extract Messages
 
 Extract messages into a PO-Template.
 
-:Copyright: (c) 2009 Accense Technology, Inc. 
+:Copyright: (c) 2009 Accense Technology, Inc.
                      Takashi Matsuo <tmatsuo@candit.jp>,
                      All rights reserved.
 :copyright: (c) 2009 by the Zine Team, see AUTHORS for more details.
@@ -116,9 +116,21 @@ def do_extract_messages(target=('t', ''), domain=('d', 'messages'),
                                COMMENT_TAGS, callback=callback,
                                strip_comment_tags=True)
 
-  for filename, lineno, message, comments in extracted:
+
+  # original kay code
+  # for filename, lineno, message, comments in extracted:
+    # catalog.add(message, None, [(strip_path(filename, root), lineno)],
+                # auto_comments=comments)
+  # raise ValueError: too many values to unpack
+
+  for phrase in extracted:
+    filename = phrase[0]
+    lineno = phrase[1]
+    message = phrase[2]
+    comments = phrase[3]
     catalog.add(message, None, [(strip_path(filename, root), lineno)],
-                auto_comments=comments)
+            auto_comments=comments)
+
   if not i18n_dir:
     i18n_dir = path.join(root, 'i18n')
   if not path.isdir(i18n_dir):

--- a/project/main/i18n/ja/LC_MESSAGES/messages.po
+++ b/project/main/i18n/ja/LC_MESSAGES/messages.po
@@ -1,0 +1,87 @@
+# Japanese translations for PROJECT.
+# Copyright (C) 2016 Takashi Matsuo
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: tmatsuo@candit.jp\n"
+"POT-Creation-Date: 2016-05-04 23:43+0900\n"
+"PO-Revision-Date: 2016-05-04 14:14+0900\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.3.4\n"
+
+#: main/views.py:161
+msgid "Upcoming Event"
+msgstr "直近のイベント"
+
+#: main/templates/403.html:7
+msgid "Not Authorized"
+msgstr "認証されていません"
+
+#: main/templates/403.html:12 main/templates/base.html:219
+#: main/templates/login.html:7 main/templates/login.html:24
+msgid "Login"
+msgstr "ログイン"
+
+#: main/templates/base.html:10 main/templates/base.html:200
+#: main/templates/index.html:7
+msgid "Event Calendar"
+msgstr "イベントカレンダー"
+
+#: main/templates/base.html:205 main/templates/index.html:113
+msgid "Add Event"
+msgstr "イベントを追加"
+
+#: main/templates/base.html:209
+msgid "From Template"
+msgstr "テンプレートから作成"
+
+#: main/templates/base.html:211
+msgid "manage templates"
+msgstr "テンプレートの管理"
+
+#: main/templates/base.html:217
+msgid "Logout"
+msgstr "ログアウト"
+
+#: main/templates/base.html:247
+msgid "failed"
+msgstr "更新にに失敗しました"
+
+#: main/templates/event_update.html:7
+msgid "Event Editor"
+msgstr "イベントを編集"
+
+#: main/templates/event_update.html:33
+msgid "Save"
+msgstr "保存"
+
+#: main/templates/index.html:14
+msgid "Loading..."
+msgstr "更新中..."
+
+#: main/templates/index.html:54
+msgid "Edit"
+msgstr "編集"
+
+#: main/templates/index.html:105
+msgid "Events"
+msgstr "イベント"
+
+#: main/templates/index.html:112
+msgid "no events"
+msgstr "イベントはありません"
+
+#: main/templates/login.html:9
+msgid "Login failed"
+msgstr "ログインに失敗しました"
+

--- a/project/main/templates/403.html
+++ b/project/main/templates/403.html
@@ -4,12 +4,12 @@
 {% block content %}
 <div class="container">
   <div class="blog-header">
-    <h1 class="blog-title">Not Authorized</h1>
+      <h1 class="blog-title">{{_('Not Authorized')}}</h1>
   </div>
   <div class="row">
     <div class="col-sm-8 blog-main">
       <div class="blog-post">
-        <a href="/login" class="btn btn-default"><span class="glyphicon glyphicon-log-in">Login</span></a>
+          <a href="/login" class="btn btn-default"><span class="glyphicon glyphicon-log-in">{{_('Login')}}</span></a>
       </div>
     </div>
   </div>

--- a/project/main/templates/base.html
+++ b/project/main/templates/base.html
@@ -7,7 +7,7 @@
   <meta name="description" content="{% block description %}{% endblock %}">
   <meta name="author" content="">
   <link rel="shortcut icon" href="/favicon.ico">
-  <title>{% block title %}{% endblock %} Event Calendar</title>
+  <title>{% block title %}{% endblock %} {{_('Event Calendar')}}</title>
   <!-- Latest compiled and minified CSS -->
   <link rel="stylesheet" href="/media/css/flatly.min.css">
   <link rel="stylesheet" href="/media/css/bootstrap-datetimepicker.min.css">
@@ -197,26 +197,26 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="/">Event Calendar</a>
+      <a class="navbar-brand" href="/">{{_('Event Calendar')}}</a>
     </div>
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-          <a href="/event/create"><span class="glyphicon glyphicon-plus"></span>Add Event</a>
+            <a href="/event/create"><span class="glyphicon glyphicon-plus"></span>{{_('Add Event')}}</a>
         </li>
         <li class="dropdown">
           <a href="/event/create" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
-             aria-expanded="false">From Template<span class="caret"></span></a>
+           aria-expanded="false">{{_('From Template')}}<span class="caret"></span></a>
           <ul class="dropdown-menu" id="dropdown-template">
-            <li><a href="/eventtemplate/list">manage templates</a></li>
+              <li><a href="/eventtemplate/list">{{_('manage templates')}}</a></li>
           </ul>
         </li>
       </ul>
       <ul class="nav navbar-nav navbar-right">
         {% if request.session['editor'] == True %}
-          <li><a href="{{ url_for('main/logout') }}">Logout</a></li>
+        <li><a href="{{ url_for('main/logout') }}">{{_('Logout')}}</a></li>
         {% else %}
-          <li><a href="{{ url_for('main/login') }}">Login</a></li>
+        <li><a href="{{ url_for('main/login') }}">{{_('Login')}}</a></li>
         {% endif %}
       </ul>
     </div>
@@ -240,11 +240,11 @@
     }).done(function (data) {
       var listHTML = "";
       $.each(data.templates, function () {
-        listHTML += '<li><a href="/event/create#' + String(this.id) + '">' + this.template_name + '</a></li>';
+          listHTML += '<li><a href="/event/create#' + String(this.id) + '">' +  this.template_name + '</a></li>';
       });
       $("#dropdown-template").append(listHTML);
     }).fail(function (data) {
-      $("#dropdown-template").append('<li>failed</li>');
+        $("#dropdown-template").append('<li>{{_('failed')}}</li>');
     });
 
   });

--- a/project/main/templates/event_update.html
+++ b/project/main/templates/event_update.html
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     <div class="blog-header">
-      <h1 class="blog-title">Event Editor</h1>
+        <h1 class="blog-title">{{_('Event Editor')}}</h1>
     </div>
     <div class="row">
       <div class="col-sm-8 blog-main">
@@ -24,7 +24,7 @@
               {% endif %}
               {% if f.errors|length > 0 %}
                 {% for e in f.errors %}
-                  <div class="alert alert-warning" role="alert">{{ e }}</div>
+                <div class="alert alert-warning" role="alert"> {{ e }} </div>
                 {% endfor %}
               {% endif %}
             </div>

--- a/project/main/templates/index.html
+++ b/project/main/templates/index.html
@@ -4,14 +4,14 @@
 {% block content %}
     <div class="container">
         <div class="blog-header">
-            <h1 class="blog-title">Event Calendar</h1>
+            <h1 class="blog-title">{{_('Event Calendar')}}</h1>
         </div>
         <div class="row">
             <div class="col-sm-5">
                 {{ calendar|safe }}
             </div>
             <div class="col-sm-7 blog-main" id="event-feed">
-              <button class="btn btn-lg btn-warning"><span class="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span> Loading...</button>
+                <button class="btn btn-lg btn-warning"><span class="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span> {{_('Loading...')}}</button>
             </div>
         </div>
     </div>
@@ -51,7 +51,7 @@
                     <p>$date</p>
                     <p>$description</p>
                     <a type="button" class="btn btn-default" aria-label="Left Align" href="/event/update/$key">
-                      <span class="glyphicon glyphicon-edit" aria-hidden="true">Edit</span>
+                    <span class="glyphicon glyphicon-edit" aria-hidden="true">{{_('Edit')}}</span>
                     </a>
                 </div>
                 <hr/>
@@ -102,15 +102,15 @@
       }
       function drawEventList(eventByDay, aDay){
         console.log('selected!:'+aDay);
-        var feedHTML = "<h2>"+aDay+"&nbsp;Events</h2>";
+        var feedHTML = "<h2>"+aDay+"&nbsp;{{_('Events')}}</h2>";
         if(aDay in eventByDay) {
           $.each(eventByDay[aDay], function(){
             feedHTML += this;
           });
           $("#event-feed").html(feedHTML);
         }else{
-          feedHTML +='<div class="blog-post"><h3 class="blog-post-title">no events</h3>';
-          feedHTML +='<a href="/event/create" class="btn btn-default">Add Event</a></div>';
+          feedHTML +='<div class="blog-post"><h3 class="blog-post-title">{{_('no events')}}</h3>';
+          feedHTML +='<a href="/event/create" class="btn btn-default">{{_('Add Event')}}</a></div>';
           $("#event-feed").html(feedHTML);
         }
       }

--- a/project/main/templates/login.html
+++ b/project/main/templates/login.html
@@ -4,9 +4,9 @@
 {% block content %}
 <div class="container">
   <div class="blog-header">
-    <h1 class="blog-title">Login</h1>
+      <h1 class="blog-title">{{_('Login')}}</h1>
     {% if request.args['error'] == 'invalid' %}
-    <p class="lead blog-description">Login failed</p>
+    <p class="lead blog-description">{{_('Login failed')}}</p>
     {% endif %}
   </div>
  <div class="row">
@@ -21,7 +21,7 @@
         </div>
         {% endfor %}
         <div class="form-actions">
-          <button class="btn btn-lg btn-block btn-primary" type="submit">Login</button>
+            <button class="btn btn-lg btn-block btn-primary" type="submit">{{_('Login')}}</button>
         </div>
       {% endcall %}
     </div>

--- a/project/main/views.py
+++ b/project/main/views.py
@@ -7,6 +7,7 @@ from werkzeug import redirect, Response
 from google.appengine.api import memcache
 from kay.utils import render_to_response, url_for, render_json_response
 from kay.utils import forms
+from kay.i18n import gettext as _
 from core.models import Editor, Event, EventTemplate, LiveSetting
 from admin.urls import generate_password
 
@@ -157,7 +158,7 @@ def event_feed(request):
         now = datetime.now()
         theyear = now.year
         themonth = now.month
-        feed_title = 'Upcoming Event'
+        feed_title = _('Upcoming Event')
     first_day_of_themonth = datetime(theyear, themonth, 1) + timedelta(days=-1)
     three_month_after = add_months(first_day_of_themonth, 2)
     results = Event.all().filter(u'event_date >=', first_day_of_themonth).filter(


### PR DESCRIPTION
ref) http://blog1.erp2py.com/2010/11/kay_29.html
This PR mainly focuses on preparing internationalization and localization in kay-framework
I admit that this localization of `main` needs to be improved.

The PR contains,
- tiny fixations about kay-derived code
  - Although that may be due to version diffs' GAE(1.9.36) or pybabel(2.3.4), it is a shame but I am not sure
  - I made the fixations backward compatible
- additional README.md about how to internationalize and localize in this repo
  - Anyone easily update translations in any langs along this note
- `main` app localization in ja
  - needs to be improved. (Local month names and so on)
## 

Please check them after changing

```
USE_I18N = True
DEFAULT_LANG = 'ja'
```

in `project/settings.py`

`tox` was passed in my local machine but raised error in CI

```
The Google App Engine SDK could not be found!
Please visit http://kay-docs.shehas.net/ for installation instructions.
ERROR: InvocationError: '/home/ubuntu/calendar-app/.tox/py27/bin/python project/manage.py test -v2'
```

Thanks,
