### PR TITLE
[fix] download ical files corresponding to individual events

### DIFF
--- a/project/main/tests/__init__.py
+++ b/project/main/tests/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-from test_views import DownloadicsTesta  # noqa
+from test_views import DownloadicsTest  # noqa

--- a/project/main/tests/__init__.py
+++ b/project/main/tests/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-from test_views import DownloadicsTest # noqa
+from test_views import DownloadicsTesta  # noqa

--- a/project/main/tests/__init__.py
+++ b/project/main/tests/__init__.py
@@ -1,1 +1,2 @@
 # -*- coding: utf-8 -*-
+from test_views import *

--- a/project/main/tests/__init__.py
+++ b/project/main/tests/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-from test_views import *
+from test_views import *  # noqa

--- a/project/main/tests/__init__.py
+++ b/project/main/tests/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-from test_views import *  # noqa
+from test_views import DownloadicsTest # noqa

--- a/project/main/tests/test_views.py
+++ b/project/main/tests/test_views.py
@@ -1,0 +1,7 @@
+from kay.ext.testutils.gae_test_base import GAETestBase
+
+class ModelTest(GAETestBase):
+    def test_hoge(self):
+        r = None
+        self.assertTrue(r is None)
+

--- a/project/main/tests/test_views.py
+++ b/project/main/tests/test_views.py
@@ -1,7 +1,47 @@
+# :coding=utf-8:
+
+import datetime
+import icalendar
+import urlparse
 from kay.ext.testutils.gae_test_base import GAETestBase
+from kay.app import get_application
+from werkzeug import BaseResponse, Client
 
-class ModelTest(GAETestBase):
-    def test_hoge(self):
-        r = None
-        self.assertTrue(r is None)
+from core.models import Event
 
+
+class DownloadicsTest(GAETestBase):
+
+    def setUp(self):
+        app = get_application()
+        self.client = Client(app, BaseResponse)
+
+        self.test_values = {
+            'date': datetime.datetime(2016, 5, 20, 15, 0),
+            'title': 'THIS IS TITLE',
+            'description': 'THIS IS TITLE',
+        }
+
+        eve = Event(
+            event_date=self.test_values['date'],
+            title=self.test_values['title'],
+            description=self.test_values['description'],
+        )
+        eve.put()
+        events = Event.all().fetch(100)
+        self.assertEquals(len(events), 1)
+        self.assertEquals(events[0].title, 'THIS IS TITLE')
+        self.event_key = str(events[0].key())
+
+    def test_download_individual_icsfile(self):
+        target_url = urlparse.urljoin('/ical/', self.event_key)
+        res = self.client.get(target_url)
+        self.assertEquals(res.status_code, 200)
+
+        downloaded = res.get_data()
+        reparsed = icalendar.Calendar.from_ical(downloaded)
+        reparsed_eve = reparsed.walk('VEVENT')[0]
+        stringfied = self.test_values['date'].strftime('%Y%m%dT%H%M%S')
+        self.assertEquals(reparsed_eve['summary'].to_ical(), self.test_values['title'])
+        self.assertEquals(reparsed_eve['dtstart'].to_ical(), stringfied)
+        self.assertEquals(reparsed_eve['description'].to_ical(), self.test_values['description'])

--- a/project/main/tests/test_views.py
+++ b/project/main/tests/test_views.py
@@ -1,4 +1,4 @@
-# :coding=utf-8:
+# -*- coding: utf-8 -*-
 
 import datetime
 import icalendar

--- a/project/main/views.py
+++ b/project/main/views.py
@@ -189,8 +189,15 @@ def ical(request, event_key):
     if event is None:
         return render_json_response({'error': '404 not found'}, mimetype='application/json', status=404)
     cal = icalendar.Calendar()
-    cal['dtstart'] = event.event_date.strftime('%Y%m%dT%H%M%S')
-    cal['summary'] = event.description
+    eve = icalendar.Event()
+    eve['dtstart'] = event.event_date.strftime('%Y%m%dT%H%M%S')
+    eve['created'] = event.created_at.strftime('%Y%m%dT%H%M%S')
+    eve['last-modified'] = event.updated_at.strftime('%Y%m%dT%H%M%S')
+    eve['summary'] = event.title
+    eve['description'] = event.description
+    eve['event_key'] = event_key
+    eve['updated_log'] = event.updated_log
+    cal.add_component(eve)
     return Response(cal.to_ical(), status=200, mimetype="text/calendar",
                     headers={'Content-Disposition': 'inline; filename=event.ics'})
 


### PR DESCRIPTION
related yosukesuzuki#1

in `main` views, the function `ical` has already been implemented.
But the files provided by `ical` is not importablw with Google Calendar or iCal (Apple) correctly.
It is the issue that the format of files fed by `main.views.ical` is not regular.

This PR will fix it and write a test for `main.views.ical`

For now, I do not create any front-end parts for it, please input "/ical/<event key>" directly for checking
## 

it may be useful for users to export one ics file containing all events and to import ics files which are exported in Google Calendar or iCal.
Next, I will push such a thing
